### PR TITLE
chore: clarify silent catches and add --effort usage example

### DIFF
--- a/cli/src/args.ts
+++ b/cli/src/args.ts
@@ -50,6 +50,7 @@ export function usageText(version) {
     '  council --no-gemini --summarizer claude "Review this plan"',
     '  council --headless --json "Summarize the implementation options"',
     '  council --json-stream --codex --claude "Compare these designs"',
+    '  council --effort high "Analyze the tradeoffs for this architecture"',
     '',
     'Selection:',
     '  --members <list>          Ordered subset of codex,claude,gemini',

--- a/cli/src/engines.ts
+++ b/cli/src/engines.ts
@@ -347,7 +347,9 @@ async function mergeGeminiSettings({ settingsPath, thinkingBudget }) {
         thinkingBudget
       };
     }
-  } catch {}
+  } catch {
+    // Existing settings file is missing or unparseable; proceed with defaults.
+  }
 
   return nextSettings;
 }
@@ -680,6 +682,7 @@ function parseJsonLines(text) {
       try {
         return [JSON.parse(line)];
       } catch {
+        // Skip non-JSON lines.
         return [];
       }
     });


### PR DESCRIPTION
## Summary

- Add explanatory comments to two bare `catch {}` blocks in `engines.ts` — every other empty catch in the file already has one, these two were overlooked
- Add an `--effort` example to the CLI help text; the flag is documented in the Execution section but absent from the examples, making it easy to miss

## Changes

- `cli/src/engines.ts` — `mergeGeminiSettings`: `catch {}` → `catch { // Existing settings file is missing or unparseable; proceed with defaults. }`
- `cli/src/engines.ts` — `parseJsonLines`: `catch {}` → `catch { // Skip non-JSON lines. }`
- `cli/src/args.ts` — `usageText`: add `council --effort high "Analyze the tradeoffs for this architecture"` to examples

## Test plan

- [x] `council --help` shows the new effort example
- [x] No behavioral changes (comments and help text only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)