### PR TITLE
[codex] Fix Claude OAuth auth

### DIFF
--- a/cli/src/engines.ts
+++ b/cli/src/engines.ts
@@ -224,7 +224,6 @@ async function runClaude({ prompt, cwd, timeoutMs, env, effort, onProgress }) {
   const commandResult = await runCommand({
     command: bin,
     args: [
-      '--bare',
       '-p',
       '--permission-mode',
       'plan',

--- a/cli/test/engines.test.js
+++ b/cli/test/engines.test.js
@@ -219,6 +219,29 @@ test('runEngine forwards --effort to claude via --effort', async () => {
   }
 });
 
+test('runEngine does not pass --bare to claude so OAuth auth remains available', async () => {
+  const fake = await createFakeCouncilEnvironment({
+    claude: { member: { mode: 'echo-argv' } }
+  });
+
+  try {
+    const result = await runEngine('claude', {
+      prompt: 'hi',
+      cwd: process.cwd(),
+      timeoutMs: 5_000,
+      env: fake.env
+    });
+
+    assert.equal(result.status, 'ok');
+    const argv = JSON.parse(result.output);
+    assert.equal(argv.includes('--bare'), false);
+    assert.ok(argv.includes('-p'), 'claude should still run in print mode');
+    assert.equal(argv.includes('--no-session-persistence'), true);
+  } finally {
+    await fake.cleanup();
+  }
+});
+
 test('runEngine forwards --effort to gemini via thinkingBudget settings (no model swap)', async () => {
   const fake = await createFakeCouncilEnvironment({
     gemini: { member: { mode: 'echo-env' } }


### PR DESCRIPTION
Fixes #9 by removing `--bare` from Claude invocations so Claude Code can use subscription/OAuth auth in headless Council runs while preserving print mode, plan permissions, stream-json output, partial messages, and no session persistence.
Adds a regression test that asserts Council no longer passes `--bare` to Claude and still sends the expected non-interactive flags.
Root cause: `--bare` disables Claude Code plugins/MCP/hooks/skills and also bypasses the OAuth auth bridge, leaving `apiKeySource` as `none` for users without `ANTHROPIC_API_KEY`.
Validated with `npm test -- test/engines.test.js`, `npm test`, `npm run typecheck`, `npm run build`, and a local Claude Code smoke test.
